### PR TITLE
Detect naked links in content

### DIFF
--- a/includes/rules.php
+++ b/includes/rules.php
@@ -330,6 +330,14 @@ return [
 		'ruleset'   => 'js',
 	],
 	[
+		'title'     => esc_html__( 'Naked Link', 'accessibility-checker' ),
+		'info_url'  => 'https://a11ychecker.com/help/naked-link',
+		'slug'      => 'naked_link',
+		'rule_type' => 'warning',
+		'summary'   => esc_html__( 'A Naked Link warning appears when a link uses the raw URL as its text content. This makes it difficult for screen reader users to understand the purpose of the link, and raw URLs can be long and cumbersome to listen to. To fix this warning, replace the URL text with descriptive text that explains where the link goes or what action it performs.', 'accessibility-checker' ),
+		'ruleset'   => 'js',
+	],
+	[
 		'title'     => esc_html__( 'Underlined Text', 'accessibility-checker' ),
 		'info_url'  => 'https://a11ychecker.com/help1978',
 		'slug'      => 'underlined_text',

--- a/src/pageScanner/checks/link-is-naked.js
+++ b/src/pageScanner/checks/link-is-naked.js
@@ -1,0 +1,96 @@
+export default {
+	id: 'link-is-naked',
+	evaluate( node ) {
+		// Skip if the link has no href attribute
+		if ( ! node.hasAttribute( 'href' ) ) {
+			return false;
+		}
+
+		// Get the href value
+		const href = node.getAttribute( 'href' ).trim();
+		
+		// Skip empty hrefs or anchors
+		if ( ! href || href === '#' || href.startsWith( '#' ) ) {
+			return false;
+		}
+
+		// Get the text content of the link
+		const linkText = node.textContent.trim();
+		
+		// Skip if link has no text content
+		if ( ! linkText ) {
+			return false;
+		}
+
+		// Check if link has aria-label that's different from href
+		const ariaLabel = node.getAttribute( 'aria-label' );
+		if ( ariaLabel && ariaLabel.trim() !== '' && ariaLabel.trim() !== href ) {
+			return false;
+		}
+
+		// Check aria-labelledby
+		if ( node.hasAttribute( 'aria-labelledby' ) ) {
+			const labelledbyIds = node.getAttribute( 'aria-labelledby' ).split( ' ' );
+			const labelledbyElements = labelledbyIds.map( ( id ) => document.getElementById( id ) ).filter( Boolean );
+			const labelledbyText = labelledbyElements.map( ( el ) => el.textContent.trim() ).join( ' ' ).trim();
+			if ( labelledbyText && labelledbyText !== href ) {
+				return false;
+			}
+		}
+
+		// Normalize URLs for comparison
+		// Remove protocol (http://, https://, ftp://, etc.)
+		const normalizeUrl = ( url ) => {
+			return url
+				.replace( /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//, '' ) // Remove protocol
+				.replace( /^www\./, '' ) // Remove www.
+				.replace( /\/$/, '' ); // Remove trailing slash
+		};
+
+		// Also check for common URL patterns that might be in the text
+		const urlPatterns = [
+			/^https?:\/\//i,
+			/^ftp:\/\//i,
+			/^mailto:/i,
+			/^tel:/i,
+			/^www\./i,
+			/^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(\/|$)/ // domain.com pattern
+		];
+
+		// Check if the text looks like a URL
+		const textLooksLikeUrl = urlPatterns.some( pattern => pattern.test( linkText ) );
+		
+		if ( ! textLooksLikeUrl ) {
+			return false;
+		}
+
+		// Normalize both href and text for comparison
+		const normalizedHref = normalizeUrl( href );
+		const normalizedText = normalizeUrl( linkText );
+
+		// Check if the normalized text matches the normalized href
+		// or if the text is contained within the href (or vice versa)
+		if ( normalizedText === normalizedHref || 
+			 normalizedHref.includes( normalizedText ) || 
+			 normalizedText.includes( normalizedHref ) ) {
+			return true;
+		}
+
+		// Additional check for mailto: and tel: links
+		if ( href.startsWith( 'mailto:' ) ) {
+			const email = href.substring( 7 ).split( '?' )[0]; // Remove mailto: and any query params
+			if ( linkText === email || linkText === href ) {
+				return true;
+			}
+		}
+
+		if ( href.startsWith( 'tel:' ) ) {
+			const phone = href.substring( 4 ); // Remove tel:
+			if ( linkText === phone || linkText === href ) {
+				return true;
+			}
+		}
+
+		return false;
+	},
+};

--- a/src/pageScanner/config/rules.js
+++ b/src/pageScanner/config/rules.js
@@ -67,6 +67,8 @@ import hasSubheadingsIfLongContent from '../checks/has-subheadings-if-long-conte
 import imageAnimated from '../rules/img-animated';
 import imageAnimatedCheck from '../checks/img-animated-check';
 import alwaysFail from '../checks/always-fail';
+import nakedLink from '../rules/naked-link';
+import linkIsNaked from '../checks/link-is-naked';
 
 // Define all the custom rules to be used.
 export const rulesArray = [
@@ -104,6 +106,7 @@ export const rulesArray = [
 	imageAnimated,
 	ariaHiddenValidation,
 	ariaBrokenReference,
+	nakedLink,
 ];
 
 // Define all the custom checks to be used.
@@ -148,6 +151,7 @@ export const checksArray = [
 	ariaLabelNotFoundCheck,
 	ariaDescribedByNotFoundCheck,
 	ariaOwnsNotFoundCheck,
+	linkIsNaked,
 ];
 
 // Define the standard axe core rules to be used.

--- a/src/pageScanner/rules/naked-link.js
+++ b/src/pageScanner/rules/naked-link.js
@@ -1,0 +1,14 @@
+export default {
+	id: 'naked_link',
+	selector: 'a[href]',
+	excludeHidden: true,
+	tags: [ 'wcag2a', 'wcag2.4.4' ],
+	metadata: {
+		description: 'Ensures links do not use raw URLs as their text content',
+		help: 'Links should use descriptive text instead of raw URLs',
+		helpUrl: 'https://a11ychecker.com/help/naked-link',
+	},
+	any: [],
+	all: [ 'link-is-naked' ],
+	none: [],
+};

--- a/tests/jest/rules/nakedLink.test.js
+++ b/tests/jest/rules/nakedLink.test.js
@@ -1,0 +1,218 @@
+import axe from 'axe-core';
+
+beforeAll( async () => {
+	// Dynamically import the custom rule
+	const nakedLinkRuleModule = await import( '../../../src/pageScanner/rules/naked-link.js' );
+	const linkIsNakedCheckModule = await import( '../../../src/pageScanner/checks/link-is-naked.js' );
+	const nakedLinkRule = nakedLinkRuleModule.default;
+	const linkIsNakedCheck = linkIsNakedCheckModule.default;
+
+	// Configure axe with the custom rule
+	axe.configure( {
+		rules: [ nakedLinkRule ],
+		checks: [ linkIsNakedCheck ],
+	} );
+} );
+
+beforeEach( () => {
+	document.body.innerHTML = '';
+} );
+
+describe( 'Naked Link Validation', () => {
+	const testCases = [
+		// Passing cases (should NOT trigger warning)
+		{
+			name: 'should pass for link with descriptive text',
+			html: '<a href="https://example.com">Visit our website</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link with descriptive text that contains domain',
+			html: '<a href="https://example.com">Example.com homepage</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link with aria-label',
+			html: '<a href="https://example.com" aria-label="Visit our homepage">https://example.com</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for anchor links',
+			html: '<a href="#section">Jump to section</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for anchor links with URL-like text',
+			html: '<a href="#contact">https://contact-us</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for empty href',
+			html: '<a href="">Click here</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for href with only hash',
+			html: '<a href="#">Top</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link without href',
+			html: '<a>https://example.com</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link with aria-labelledby',
+			html: '<span id="link-label">Visit our site</span><a href="https://example.com" aria-labelledby="link-label">https://example.com</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for link with text that is not a URL',
+			html: '<a href="https://example.com">Learn more about our products</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for relative links with descriptive text',
+			html: '<a href="/about">About Us</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for email links with descriptive text',
+			html: '<a href="mailto:contact@example.com">Contact us via email</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass for phone links with descriptive text',
+			html: '<a href="tel:+1234567890">Call us</a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass when link text is empty',
+			html: '<a href="https://example.com"></a>',
+			shouldPass: true,
+		},
+		{
+			name: 'should pass when href and text are completely different',
+			html: '<a href="https://example.com">https://different-site.com</a>',
+			shouldPass: true,
+		},
+
+		// Failing cases (should trigger warning)
+		{
+			name: 'should fail for link with URL as text (https)',
+			html: '<a href="https://example.com">https://example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with URL as text (http)',
+			html: '<a href="http://example.com">http://example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with URL as text without protocol in text',
+			html: '<a href="https://example.com">example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with www URL as text',
+			html: '<a href="https://www.example.com">www.example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with URL including path',
+			html: '<a href="https://example.com/about">https://example.com/about</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with URL including path without protocol in text',
+			html: '<a href="https://example.com/about">example.com/about</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link with URL with trailing slash',
+			html: '<a href="https://example.com/">https://example.com/</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for link where text is URL without trailing slash',
+			html: '<a href="https://example.com/">https://example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for FTP links',
+			html: '<a href="ftp://files.example.com">ftp://files.example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for mailto links with email as text',
+			html: '<a href="mailto:contact@example.com">contact@example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for mailto links with full mailto URL as text',
+			html: '<a href="mailto:contact@example.com">mailto:contact@example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for tel links with phone number as text',
+			html: '<a href="tel:+1234567890">+1234567890</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for tel links with full tel URL as text',
+			html: '<a href="tel:+1234567890">tel:+1234567890</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when href has www but text doesn\'t',
+			html: '<a href="https://www.example.com">example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when text has www but href doesn\'t',
+			html: '<a href="https://example.com">www.example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for subdomain URLs',
+			html: '<a href="https://blog.example.com">blog.example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for URLs with query parameters',
+			html: '<a href="https://example.com?ref=home">example.com?ref=home</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for URLs with fragments',
+			html: '<a href="https://example.com#section">example.com#section</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail when text looks like domain',
+			html: '<a href="/home">example.com</a>',
+			shouldPass: false,
+		},
+		{
+			name: 'should fail for multiple naked links',
+			html: '<a href="https://example.com">https://example.com</a> and <a href="https://test.com">test.com</a>',
+			shouldPass: false,
+		},
+	];
+
+	testCases.forEach( ( testCase ) => {
+		test( testCase.name, async () => {
+			document.body.innerHTML = testCase.html;
+
+			const results = await axe.run( document.body, {
+				runOnly: [ 'naked_link' ],
+			} );
+
+			if ( testCase.shouldPass ) {
+				expect( results.violations.length ).toBe( 0 );
+			} else {
+				expect( results.violations.length ).toBeGreaterThan( 0 );
+			}
+		} );
+	} );
+} );


### PR DESCRIPTION
Adds a new accessibility rule (`naked_link`) to detect "naked links" where the link's visible text content is a raw URL that matches its `href` attribute. This improves link purpose clarity for screen reader users, aligning with WCAG 2.4.4.

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes

---
<a href="https://cursor.com/background-agent?bcId=bc-e09c55fb-8cad-46e4-992a-5f5c70d67570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e09c55fb-8cad-46e4-992a-5f5c70d67570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

