### PR TITLE
Detect naked links in content

### DIFF
--- a/includes/rules.php
+++ b/includes/rules.php
@@ -330,6 +330,14 @@ return [
 		'ruleset'   => 'js',
 	],
 	[
+		'title'     => esc_html__( 'Naked Link', 'accessibility-checker' ),
+		'info_url'  => 'https://a11ychecker.com/help', // Update with actual help URL when available
+		'slug'      => 'naked_link',
+		'rule_type' => 'error',
+		'summary'   => esc_html__( 'A Naked Link error appears when a link\'s visible text is just the raw URL itself (e.g., "https://example.com" instead of descriptive text). This creates accessibility issues because screen readers will read the URL twice - once as the link text and once as the destination. To resolve this error, replace the URL text with meaningful, descriptive text that explains where the link goes or what action it performs.', 'accessibility-checker' ),
+		'ruleset'   => 'js',
+	],
+	[
 		'title'     => esc_html__( 'Underlined Text', 'accessibility-checker' ),
 		'info_url'  => 'https://a11ychecker.com/help1978',
 		'slug'      => 'underlined_text',

--- a/src/pageScanner/checks/naked-link.js
+++ b/src/pageScanner/checks/naked-link.js
@@ -1,0 +1,131 @@
+/**
+ * Check if a link contains "naked" text that matches its href attribute.
+ * A naked link is when the visible text is just the URL itself.
+ * 
+ * Examples of naked links:
+ * - <a href="https://example.com">https://example.com</a>
+ * - <a href="http://www.example.com">http://www.example.com</a>
+ * - <a href="https://example.com/page">https://example.com/page</a>
+ * 
+ * This is an accessibility issue because screen reader users hearing the URL
+ * read out twice provides no additional context about the link's purpose.
+ */
+
+export default {
+	id: 'naked_link',
+	evaluate: ( node ) => {
+		// Only check anchor elements
+		if ( node.nodeName.toLowerCase() !== 'a' ) {
+			return false;
+		}
+
+		// Get the href attribute
+		const href = node.getAttribute( 'href' );
+		if ( ! href ) {
+			return false;
+		}
+
+		// Skip mailto, tel, and other special protocol links
+		const specialProtocols = [ 'mailto:', 'tel:', 'sms:', 'fax:', 'javascript:', '#' ];
+		if ( specialProtocols.some( protocol => href.startsWith( protocol ) ) ) {
+			return false;
+		}
+
+		// Get the visible text content of the link
+		let linkText = '';
+
+		// First check for aria-label
+		if ( node.hasAttribute( 'aria-label' ) ) {
+			linkText = node.getAttribute( 'aria-label' );
+		}
+		// Then check for aria-labelledby
+		else if ( node.hasAttribute( 'aria-labelledby' ) ) {
+			const labelIds = node.getAttribute( 'aria-labelledby' ).split( ' ' );
+			const labelTexts = labelIds.map( id => {
+				const element = document.getElementById( id );
+				return element ? element.textContent : '';
+			} );
+			linkText = labelTexts.join( ' ' );
+		}
+		// Otherwise use the text content
+		else {
+			linkText = node.textContent || '';
+		}
+
+		// Clean up the text - trim whitespace and normalize
+		linkText = linkText.trim();
+		
+		// If there's no text, this is not a naked link issue (it's an empty link issue)
+		if ( ! linkText ) {
+			return false;
+		}
+
+		// Normalize both href and text for comparison
+		const normalizedHref = href.trim().toLowerCase();
+		const normalizedText = linkText.trim().toLowerCase();
+
+		// Direct match check
+		if ( normalizedHref === normalizedText ) {
+			return true;
+		}
+
+		// Check if text matches href without protocol
+		const hrefWithoutProtocol = normalizedHref.replace( /^https?:\/\//, '' );
+		if ( hrefWithoutProtocol === normalizedText ) {
+			return true;
+		}
+
+		// Check if text matches href without www
+		const hrefWithoutWww = normalizedHref.replace( /^https?:\/\/(www\.)?/, '' );
+		if ( hrefWithoutWww === normalizedText ) {
+			return true;
+		}
+
+		// Check if text matches href without trailing slash
+		const hrefWithoutTrailingSlash = normalizedHref.replace( /\/$/, '' );
+		const textWithoutTrailingSlash = normalizedText.replace( /\/$/, '' );
+		if ( hrefWithoutTrailingSlash === textWithoutTrailingSlash ) {
+			return true;
+		}
+
+		// Check various combinations
+		const hrefVariations = [
+			normalizedHref,
+			hrefWithoutProtocol,
+			hrefWithoutWww,
+			hrefWithoutTrailingSlash,
+			hrefWithoutProtocol.replace( /\/$/, '' ),
+			hrefWithoutWww.replace( /\/$/, '' ),
+		];
+
+		const textVariations = [
+			normalizedText,
+			normalizedText.replace( /^https?:\/\//, '' ),
+			normalizedText.replace( /^https?:\/\/(www\.)?/, '' ),
+			textWithoutTrailingSlash,
+		];
+
+		// Check all combinations
+		for ( const hrefVar of hrefVariations ) {
+			for ( const textVar of textVariations ) {
+				if ( hrefVar === textVar ) {
+					return true;
+				}
+			}
+		}
+
+		// Check if the text looks like a URL pattern (even if not exact match)
+		const urlPattern = /^(https?:\/\/)?(www\.)?[a-z0-9-]+(\.[a-z0-9-]+)+(\/[a-z0-9-._~:/?#[\]@!$&'()*+,;=%]*)?$/i;
+		if ( urlPattern.test( normalizedText ) ) {
+			// If the text looks like a URL, check if it's related to the href
+			const textDomain = normalizedText.replace( /^(https?:\/\/)?(www\.)?/, '' ).split( '/' )[0];
+			const hrefDomain = normalizedHref.replace( /^(https?:\/\/)?(www\.)?/, '' ).split( '/' )[0];
+			
+			if ( textDomain === hrefDomain ) {
+				return true;
+			}
+		}
+
+		return false;
+	},
+};

--- a/src/pageScanner/config/rules.js
+++ b/src/pageScanner/config/rules.js
@@ -67,6 +67,8 @@ import hasSubheadingsIfLongContent from '../checks/has-subheadings-if-long-conte
 import imageAnimated from '../rules/img-animated';
 import imageAnimatedCheck from '../checks/img-animated-check';
 import alwaysFail from '../checks/always-fail';
+import nakedLink from '../rules/naked-link';
+import nakedLinkCheck from '../checks/naked-link';
 
 // Define all the custom rules to be used.
 export const rulesArray = [
@@ -80,6 +82,7 @@ export const rulesArray = [
 	linkAmbiguousText,
 	linkPDF,
 	linkMsOfficeFile,
+	nakedLink,
 	brokenAnchorLink,
 	labelExtended,
 	missingTableHeader,
@@ -117,6 +120,7 @@ export const checksArray = [
 	textIsJustified,
 	linkTargetBlankWithoutInforming,
 	hasAmbiguousText,
+	nakedLinkCheck,
 	anchorExists,
 	imageInputHasAlt,
 	ariaHiddenValidUsage,

--- a/src/pageScanner/rules/naked-link.js
+++ b/src/pageScanner/rules/naked-link.js
@@ -1,0 +1,32 @@
+/**
+ * Rule to detect "naked links" - links where the visible text is just the URL itself.
+ * 
+ * This is an accessibility issue because:
+ * 1. Screen readers will read the URL twice (once as link text, once as destination)
+ * 2. URLs often don't provide meaningful context about the link's purpose
+ * 3. Long URLs can be difficult to understand when read aloud
+ * 
+ * Good example: <a href="https://example.com">Visit our homepage</a>
+ * Bad example: <a href="https://example.com">https://example.com</a>
+ */
+
+export default {
+	id: 'naked_link',
+	enabled: true,
+	selector: 'a[href]',
+	excludeHidden: false,
+	tags: [
+		'cat.semantics',
+		'wcag2a',
+		'wcag244',
+		'best-practices',
+	],
+	metadata: {
+		description: 'Ensures links have descriptive text rather than raw URLs',
+		help: 'Links should have meaningful text that describes their destination, not just the URL',
+		helpUrl: 'https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html',
+	},
+	all: [],
+	any: [],
+	none: [ 'naked_link' ],
+};


### PR DESCRIPTION
Adds a new accessibility rule to detect "naked links" where the visible text of a link is identical to its `href` URL. This improves accessibility by preventing redundant information for screen reader users and encouraging more descriptive link text, aligning with WCAG 2.4.4 (Link Purpose in Context).

## Checklist

- [ ] PR is linked to the main issue in the repo
- [ ] Tests are added that cover changes

---
<a href="https://cursor.com/background-agent?bcId=bc-207ecb4f-d225-4484-beae-668f7c0c6024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-207ecb4f-d225-4484-beae-668f7c0c6024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

